### PR TITLE
[Cleanup] Remove Launcher from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,18 +16,3 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.0
     - name: Build with MSBuild
       run: msbuild RTCV.sln
-
-  Launcher:
-    runs-on: windows-2019
-    steps:
-    - uses: actions/checkout@v1
-    - name: Setup Nuget
-      uses: nuget/setup-nuget@v1.0.2
-      with:
-        nuget-version: 'latest'
-    - name: Restore packages
-      run: nuget restore .\Source\Launcher\RTC_Launcher.sln
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
-    - name: Build with MSBuild
-      run: msbuild .\Source\Launcher\RTC_Launcher.sln


### PR DESCRIPTION
Since the launch is in its own repository, we'll no longer build it from here.