### PR TITLE
Fixed CA1716 - Identifiers should not match keywords

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -266,9 +266,6 @@ dotnet_diagnostic.CA1401.severity = none
 # Do not prefix enum values with the name of the enum type 'FileType'
 dotnet_diagnostic.CA1712.severity = none
 
-# Rename virtual/interface member so it no longer conflicts with reserved language
-dotnet_diagnostic.CA1716.severity = none
-
 # Naming conflict
 dotnet_diagnostic.CA1724.severity = none
 

--- a/Source/Libraries/CorruptCore/IRealTime.cs
+++ b/Source/Libraries/CorruptCore/IRealTime.cs
@@ -8,7 +8,6 @@ namespace RTCV.CorruptCore
 
     public interface IRealTime
     {
-        event EventHandler<RealTimeEventArgs> Step;
         event EventHandler GameLoaded;
         event EventHandler GameClosed;
 

--- a/Source/Libraries/CorruptCore/IRealTime.cs
+++ b/Source/Libraries/CorruptCore/IRealTime.cs
@@ -8,6 +8,7 @@ namespace RTCV.CorruptCore
 
     public interface IRealTime
     {
+        event EventHandler<RealTimeEventArgs> StepHandler;
         event EventHandler GameLoaded;
         event EventHandler GameClosed;
 

--- a/Source/Libraries/PluginHost/Host.cs
+++ b/Source/Libraries/PluginHost/Host.cs
@@ -96,7 +96,7 @@ namespace RTCV.PluginHost
         {
             foreach (var p in _loadedPlugins)
             {
-                p.Stop();
+                p.StopPlugin();
             }
         }
 

--- a/Source/Libraries/PluginHost/IPlugin.cs
+++ b/Source/Libraries/PluginHost/IPlugin.cs
@@ -18,6 +18,6 @@ namespace RTCV.PluginHost
 
 
         bool Start(RTCSide side);
-        bool Stop();
+        bool StopPlugin();
     }
 }

--- a/Source/Plugins/HexEditor/Loader.cs
+++ b/Source/Plugins/HexEditor/Loader.cs
@@ -33,7 +33,7 @@ namespace RTCV.Plugins.HexEditor
             return true;
         }
 
-        public bool Stop()
+        public bool StopPlugin()
         {
             if (!S.ISNULL<HexEditor>())
             {

--- a/Source/Plugins/ScriptHost/Loader.cs
+++ b/Source/Plugins/ScriptHost/Loader.cs
@@ -32,7 +32,7 @@ namespace RTCV.Plugins.ScriptHost
             return true;
         }
 
-        public bool Stop()
+        public bool StopPlugin()
         {
             return true;
         }

--- a/Source/Plugins/TestPlugin/TestPlugin.cs
+++ b/Source/Plugins/TestPlugin/TestPlugin.cs
@@ -21,7 +21,7 @@ namespace RTCV.Plugins
             return true;
         }
 
-        public bool Stop()
+        public bool StopPlugin()
         {
             return true;
         }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1716?view=vs-2019

This is a particularly nice rule since we're integrating our code into C++ codebases