### PR TITLE
Fixed CA1724: Type names should not match namespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -267,9 +267,6 @@ dotnet_diagnostic.CA1401.severity = none
 # Do not prefix enum values with the name of the enum type 'FileType'
 dotnet_diagnostic.CA1712.severity = none
 
-# Naming conflict
-dotnet_diagnostic.CA1724.severity = none
-
 # Member is explicitly initialized to its default value
 dotnet_diagnostic.CA1805.severity = none
 

--- a/Source/Frontend/UI/Input/Gamepad360.cs
+++ b/Source/Frontend/UI/Input/Gamepad360.cs
@@ -55,15 +55,15 @@ namespace RTCV.UI.Input
             {
                 //some users wont even have xinput installed. in order to avoid spurious exceptions and possible instability, check for the library first
                 HasGetInputStateEx = true;
-                LibraryHandle = Win32.LoadLibrary("xinput1_3.dll");
+                LibraryHandle = NativeWin32APIs.LoadLibrary("xinput1_3.dll");
                 if (LibraryHandle == IntPtr.Zero)
                 {
-                    LibraryHandle = Win32.LoadLibrary("xinput1_4.dll");
+                    LibraryHandle = NativeWin32APIs.LoadLibrary("xinput1_4.dll");
                 }
 
                 if (LibraryHandle == IntPtr.Zero)
                 {
-                    LibraryHandle = Win32.LoadLibrary("xinput9_1_0.dll");
+                    LibraryHandle = NativeWin32APIs.LoadLibrary("xinput9_1_0.dll");
                     HasGetInputStateEx = false;
                 }
 

--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -5,29 +5,8 @@ namespace RTCV.UI.Input
     using System.Threading;
     using RTCV.NetCore;
 
-    public class Input
+    internal class Input
     {
-        /// <summary>
-        /// If your form needs this kind of input focus, be sure to say so.
-        /// Really, this only makes sense for mouse, but I've started building it out for other things
-        /// Why is this receiving a control, but actually using it as a Form (where the WantingMouseFocus is checked?)
-        /// Because later we might change it to work off the control, specifically, if a control is supplied (normally actually a Form will be supplied)
-        /// </summary>
-        public void ControlInputFocus(System.Windows.Forms.Control c, FocusTypes types, bool wants)
-        {
-            if (types.HasFlag(FocusTypes.Mouse) && wants)
-            {
-                WantingMouseFocus.Add(c);
-            }
-
-            if (types.HasFlag(FocusTypes.Mouse) && !wants)
-            {
-                WantingMouseFocus.Remove(c);
-            }
-        }
-
-        readonly HashSet<System.Windows.Forms.Control> WantingMouseFocus = new HashSet<System.Windows.Forms.Control>();
-
         public static Input Instance { get; private set; }
         readonly Thread UpdateThread;
         private bool KillUpdateThread = false;
@@ -330,39 +309,6 @@ namespace RTCV.UI.Input
 
                                 FloatValues[n] = f;
                             }
-                        }
-
-                        // analyse moose
-                        // other sorts of mouse api (raw input) could easily be added as a separate listing under a different class
-                        if (WantingMouseFocus.Contains(System.Windows.Forms.Form.ActiveForm))
-                        {
-                            var P = System.Windows.Forms.Control.MousePosition;
-                            if (trackdeltas)
-                            {
-                                // these are relative to screen coordinates, but that's not terribly important
-                                FloatDeltas["WMouse X"] += Math.Abs(P.X - FloatValues["WMouse X"]) * 50;
-                                FloatDeltas["WMouse Y"] += Math.Abs(P.Y - FloatValues["WMouse Y"]) * 50;
-                            }
-                            // coordinate translation happens later
-                            FloatValues["WMouse X"] = P.X;
-                            FloatValues["WMouse Y"] = P.Y;
-
-                            var B = System.Windows.Forms.Control.MouseButtons;
-                            HandleButton("WMouse L", (B & System.Windows.Forms.MouseButtons.Left) != 0);
-                            HandleButton("WMouse C", (B & System.Windows.Forms.MouseButtons.Middle) != 0);
-                            HandleButton("WMouse R", (B & System.Windows.Forms.MouseButtons.Right) != 0);
-                            HandleButton("WMouse 1", (B & System.Windows.Forms.MouseButtons.XButton1) != 0);
-                            HandleButton("WMouse 2", (B & System.Windows.Forms.MouseButtons.XButton2) != 0);
-                        }
-                        else
-                        {
-                            //dont do this: for now, it will interfere with the virtualpad. dont do something similar for the mouse position either
-                            //unpress all buttons
-                            //HandleButton("WMouse L", false);
-                            //HandleButton("WMouse C", false);
-                            //HandleButton("WMouse R", false);
-                            //HandleButton("WMouse 1", false);
-                            //HandleButton("WMouse 2", false);
                         }
                     }
 

--- a/Source/Libraries/CorruptCore/CorruptCoreExtensions.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreExtensions.cs
@@ -123,25 +123,10 @@ namespace RTCV.CorruptCore
     }
 
     //Lifted from Bizhawk https://github.com/TASVideos/BizHawk
-    public static class Win32
+    public static class NativeWin32APIs
     {
         [DllImport("kernel32.dll")]
         public static extern IntPtr LoadLibrary(string dllToLoad);
-
-        [DllImport("kernel32.dll")]
-        public static extern FileType GetFileType(IntPtr hFile);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr GetCommandLine();
-
-        public enum FileType : int
-        {
-            FileTypeChar = 0x0002,
-            FileTypeDisk = 0x0001,
-            FileTypePipe = 0x0003,
-            FileTypeRemote = 0x8000,
-            FileTypeUnknown = 0x0000,
-        }
 
         internal const int SW_HIDE = 0;
         internal const int SW_SHOW = 5;
@@ -156,45 +141,5 @@ namespace RTCV.CorruptCore
 
         [DllImport("user32.dll")]
         public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-
-        [DllImport("user32.dll")]
-        public static extern IntPtr GetSystemMenu(IntPtr hWndValue, bool isRevert);
-
-        [DllImport("user32.dll")]
-        public static extern int EnableMenuItem(IntPtr tMenu, int targetItem, int targetStatus);
-
-        [DllImport("user32.dll", SetLastError = true)]
-        public static extern bool SetForegroundWindow(IntPtr hWnd);
-
-        [DllImport("user32.dll", SetLastError = true)]
-        public static extern IntPtr SetActiveWindow(IntPtr hWnd);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern bool AttachConsole(int dwProcessId);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern bool AllocConsole();
-
-        [DllImport("kernel32.dll", SetLastError = false)]
-        public static extern bool FreeConsole();
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern IntPtr GetStdHandle(int nStdHandle);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern bool SetStdHandle(int nStdHandle, IntPtr hConsoleOutput);
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        public static extern IntPtr CreateFile(
-            string fileName,
-            int desiredAccess,
-            int shareMode,
-            IntPtr securityAttributes,
-            int creationDisposition,
-            int flagsAndAttributes,
-            IntPtr templateFile);
-
-        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
-        public static extern bool CloseHandle(IntPtr handle);
     }
 }

--- a/Source/Libraries/CorruptCore/LogConsole.cs
+++ b/Source/Libraries/CorruptCore/LogConsole.cs
@@ -12,15 +12,15 @@ namespace RTCV.CorruptCore
 
         public static void ShowConsole()
         {
-            var handle = Win32.GetConsoleWindow();
-            Win32.ShowWindow(handle, Win32.SW_SHOW);
+            var handle = NativeWin32APIs.GetConsoleWindow();
+            NativeWin32APIs.ShowWindow(handle, NativeWin32APIs.SW_SHOW);
             ConsoleVisible = true;
         }
 
         public static void HideConsole()
         {
-            var handle = Win32.GetConsoleWindow();
-            Win32.ShowWindow(handle, Win32.SW_HIDE);
+            var handle = NativeWin32APIs.GetConsoleWindow();
+            NativeWin32APIs.ShowWindow(handle, NativeWin32APIs.SW_HIDE);
             ConsoleVisible = false;
         }
 


### PR DESCRIPTION
`Win32` was fixed with a renamed. `Input` was fixed by making the class internal. I also deleted a bunch of dead code.