### PR TITLE
Removed Stockpile.Name member

### DIFF
--- a/Source/Libraries/CorruptCore/Stockpile/Stockpile.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/Stockpile.cs
@@ -26,12 +26,6 @@ namespace RTCV.CorruptCore
         [SuppressMessage("Microsoft.Design", "CA1051", Justification = "Unknown serialization impact of making this property instead of a field")]
         public List<StashKey> StashKeys = new List<StashKey>();
 
-        // https://github.com/redscientistlabs/RTCV/issues/241
-        #pragma warning disable 649 // Field is unused, but removing it would change how this object serializes, which could break other components
-        [JsonProperty]
-        private string Name;
-        #pragma warning restore 649
-
         [SuppressMessage("Microsoft.Design", "CA1051", Justification = "Unknown serialization impact of making this property instead of a field")]
         public string Filename;
 
@@ -62,11 +56,6 @@ namespace RTCV.CorruptCore
 
         public Stockpile()
         {
-        }
-
-        public override string ToString()
-        {
-            return Name ?? string.Empty;
         }
 
         public static bool Save(Stockpile sks, string filename, bool includeReferencedFiles = false, bool compress = true)

--- a/Source/Libraries/CorruptCore/Stockpile/Stockpile.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/Stockpile.cs
@@ -38,8 +38,8 @@ namespace RTCV.CorruptCore
         [JsonProperty]
         private string VanguardImplementation;
 
-        [SuppressMessage("Microsoft.Design", "CA1051", Justification = "Unknown serialization impact of making this property instead of a field")]
-        public bool MissingLimiter;
+        [JsonProperty]
+        internal bool MissingLimiter;
 
         public Stockpile(DataGridView dgvStockpile)
         {

--- a/Tests/CorruptCore/Serialization/Resources/DefaultStockpile505.json
+++ b/Tests/CorruptCore/Serialization/Resources/DefaultStockpile505.json
@@ -1,5 +1,6 @@
 {
   "StashKeys": [],
+  "Name": null,
   "Filename": null,
   "ShortFilename": null,
   "RtcVersion": null,

--- a/Tests/CorruptCore/Serialization/StockpileTests.cs
+++ b/Tests/CorruptCore/Serialization/StockpileTests.cs
@@ -9,6 +9,13 @@ namespace Tests.CorruptCore.Serialization
     [TestClass]
     public class StockpileTests
     {
+        private const string TestResourceFolder = "../Tests/CorruptCore/Serialization/Resources";
+        private static readonly string defaultStockpilePath = Path.Combine(TestResourceFolder, "DefaultStockpile.json");
+        private static readonly string defaultStockpile505Path = Path.Combine(TestResourceFolder, "DefaultStockpile505.json");
+
+        /// <summary>
+        /// Validate the output of serialization for a default Stockpile object.
+        /// </summary>
         [TestMethod]
         public void TestDefaultStockpileSerialization()
         {
@@ -23,7 +30,7 @@ namespace Tests.CorruptCore.Serialization
             {
                 var actualValue = actualStreamReader.ReadToEnd();
 
-                using (var streamReader = new StreamReader("../Tests/CorruptCore/Serialization/Resources/DefaultStockpile.json"))
+                using (var streamReader = new StreamReader(defaultStockpilePath))
                 {
                     var expectedValue = streamReader.ReadToEnd();
                     actualValue.Should().Be(expectedValue);
@@ -31,6 +38,33 @@ namespace Tests.CorruptCore.Serialization
             }
 
             File.Delete(tempFilePath);
+        }
+
+        [TestMethod]
+        public void TestDefaultStockpileDeserialization()
+        {
+            var expectedStockpile = new Stockpile();
+            using (var actualStreamReader = new StreamReader(defaultStockpilePath))
+            {
+                var actualStockpileSerialized = actualStreamReader.ReadToEnd();
+                var actualStockpile = JsonConvert.DeserializeObject<Stockpile>(actualStockpileSerialized);
+                actualStockpile.Should().BeEquivalentTo(expectedStockpile);
+            }
+        }
+
+        /// <summary>
+        /// Make sure that the current version of RTCV can read saved stockpiles from version 5.0.5
+        /// </summary>
+        [TestMethod]
+        public void TestDefaultStockpile505Deserialization()
+        {
+            var expectedStockpile = new Stockpile();
+            using (var actualStreamReader = new StreamReader(defaultStockpile505Path))
+            {
+                var actualStockpileSerialized = actualStreamReader.ReadToEnd();
+                var actualStockpile = JsonConvert.DeserializeObject<Stockpile>(actualStockpileSerialized);
+                actualStockpile.Should().BeEquivalentTo(expectedStockpile);
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #241 

Removed `Stockpile.Name`. This has an impact on how `Stockpile` serializes. I created `TestDefaultStockpile505Deserialization` to validate that `Stockpile`s created before this commit can still successfully be deserialized