### PR TITLE
[CI] Updated setup-msbuild tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore packages
       run: msbuild RTCV.sln /t:restore
     - name: Build with MSBuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Restore packages
       run: msbuild RTCV.sln /t:restore
     - name: Build with MSBuild

--- a/.github/workflows/buildDependants.yml
+++ b/.github/workflows/buildDependants.yml
@@ -25,7 +25,9 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -54,7 +56,9 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -83,7 +87,9 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -112,7 +118,9 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -141,7 +149,9 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -158,7 +168,9 @@ jobs:
     steps:
     # Setup tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     # Setup RTCV
     - name: Checkout current build target
@@ -204,7 +216,9 @@ jobs:
       with:
         path: 'RTCV'
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Restore Nuget packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Restore Nuget packages in dolphin-vanguard
@@ -227,7 +241,9 @@ jobs:
       with:
         path: 'RTCV'
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Restore Nuget packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Restore Nuget packages in pcsx2-Vanguard
@@ -244,7 +260,9 @@ jobs:
       with:
         path: 'RTCV'
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Restore Nuget packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Build RTCV
@@ -287,7 +305,9 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target

--- a/.github/workflows/buildDependants.yml
+++ b/.github/workflows/buildDependants.yml
@@ -25,9 +25,7 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -56,9 +54,7 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -87,9 +83,7 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -118,9 +112,7 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -149,9 +141,7 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target
@@ -168,9 +158,7 @@ jobs:
     steps:
     # Setup tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
 
     # Setup RTCV
     - name: Checkout current build target
@@ -216,9 +204,7 @@ jobs:
       with:
         path: 'RTCV'
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore Nuget packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Restore Nuget packages in dolphin-vanguard
@@ -241,9 +227,7 @@ jobs:
       with:
         path: 'RTCV'
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore Nuget packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Restore Nuget packages in pcsx2-Vanguard
@@ -260,9 +244,7 @@ jobs:
       with:
         path: 'RTCV'
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Restore Nuget packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Build RTCV
@@ -305,9 +287,7 @@ jobs:
 
     # Setup Tooling
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      uses: microsoft/setup-msbuild@v1.0.2
 
     # Restore nuget packages for all targets
     - name: Restore Nuget packages in current build target

--- a/.github/workflows/buildDependants.yml
+++ b/.github/workflows/buildDependants.yml
@@ -27,10 +27,10 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore nuget packages for all targets
-    - name: Restore Nuget packages in current build target
+    # Restore packages for all targets
+    - name: Restore packages in current build target
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in Bizhawk
+    - name: Restore packages in Bizhawk
       run: msbuild /t:restore '.\Bizhawk-Vanguard\Real-Time Corruptor\BizHawk_RTC\BizHawk.sln'
 
     # Build Bizhawk
@@ -56,10 +56,10 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore nuget packages for all targets
-    - name: Restore Nuget packages in current build target
+    # Restore packages for all targets
+    - name: Restore packages in current build target
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in CemuStub
+    - name: Restore packages in CemuStub
       run: msbuild /t:restore '.\CemuStub-Vanguard\'
 
     # Build CemuStub
@@ -85,10 +85,10 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore nuget packages for all targets
-    - name: Restore Nuget packages in current build target
+    # Restore packages for all targets
+    - name: Restore packages in current build target
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in FileStub
+    - name: Restore packages in FileStub
       run: msbuild /t:restore '.\FileStub-Vanguard\FileStub-Vanguard.sln'
 
     # Build FileStub
@@ -114,10 +114,10 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore nuget packages for all targets
-    - name: Restore Nuget packages in current build target
+    # Restore packages for all targets
+    - name: Restore packages in current build target
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in UnityStub
+    - name: Restore packages in UnityStub
       run: msbuild /t:restore '.\UnityStub-Vanguard\UnityStub-Vanguard.sln'
 
     # Build UnityStub
@@ -143,10 +143,10 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore nuget packages for all targets
-    - name: Restore Nuget packages in current build target
+    # Restore packages for all targets
+    - name: Restore packages in current build target
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in ProcessStub
+    - name: Restore packages in ProcessStub
       run: msbuild /t:restore '.\ProcessStub-Vanguard\ProcessStub-Vanguard.sln'
 
     # Build ProcessStub
@@ -165,7 +165,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: 'RTCV'
-    - name: Restore Nuget packages in RTCV
+    - name: Restore packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Build RTCV
       run: msbuild '.\RTCV\RTCV.sln'
@@ -205,9 +205,9 @@ jobs:
         path: 'RTCV'
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
-    - name: Restore Nuget packages in RTCV
+    - name: Restore packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in dolphin-vanguard
+    - name: Restore packages in dolphin-vanguard
       run: msbuild /t:restore '.\dolphin-vanguard\Source\dolphin-emu.sln'
     - name: Build with MSBuild
       run: msbuild '.\dolphin-vanguard\Source\dolphin-emu.sln' /property:Configuration=Release /property:Platform=x64 /p:TreatWarningAsError=false
@@ -228,9 +228,9 @@ jobs:
         path: 'RTCV'
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
-    - name: Restore Nuget packages in RTCV
+    - name: Restore packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in pcsx2-Vanguard
+    - name: Restore packages in pcsx2-Vanguard
       run: msbuild /t:restore '.\pcsx2-Vanguard\PCSX2_suite.sln'
     - name: Build with MSBuild
       run: msbuild '.\pcsx2-Vanguard\PCSX2_suite.sln' /property:Configuration=Debug /property:Platform=Win32
@@ -245,7 +245,7 @@ jobs:
         path: 'RTCV'
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
-    - name: Restore Nuget packages in RTCV
+    - name: Restore packages in RTCV
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
     - name: Build RTCV
       run: msbuild '.\RTCV\RTCV.sln'
@@ -289,10 +289,10 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
 
-    # Restore nuget packages for all targets
-    - name: Restore Nuget packages in current build target
+    # Restore packages for all targets
+    - name: Restore packages in current build target
       run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore Nuget packages in DosboxStub
+    - name: Restore packages in DosboxStub
       run: msbuild /t:restore '.\DosboxStub-Vanguard\DosboxStub-Vanguard.sln'
 
     # Build DosboxStub


### PR DESCRIPTION
On October 1, [GitHub deprecated commands used by `setup-msbuild`](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) to set the `PATH` environment variable. As a result, all of our CI is currently broken at the `setup-msbuild` step.

As a workaround, I've updated all of the tasks that use `setup-msbuild` to include the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable, which will override the command deprecation.

At some point, this same fix will need to be applied to all of the dependant projects for CI to work properly.