### PR TITLE
Remove UnityStub support

### DIFF
--- a/.github/workflows/buildDependants.yml
+++ b/.github/workflows/buildDependants.yml
@@ -95,35 +95,6 @@ jobs:
     - name: Build FileStub-Vanguard
       run: msbuild '.\FileStub-Vanguard\FileStub-Vanguard.sln'
 
-  UnityStub:
-    runs-on: windows-2019
-    steps:
-    # Checkout relevant code
-    - name: Checkout current build target
-      uses: actions/checkout@v2
-      with:
-        path: 'RTCV'
-    - name: Checkout UnityStub
-      uses: actions/checkout@v2
-      with:
-        repository: 'redscientistlabs/UnityStub-Vanguard'
-        ref: 'master'
-        path: 'UnityStub-Vanguard'
-
-    # Setup Tooling
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
-
-    # Restore packages for all targets
-    - name: Restore packages in current build target
-      run: msbuild /t:restore '.\RTCV\RTCV.sln'
-    - name: Restore packages in UnityStub
-      run: msbuild /t:restore '.\UnityStub-Vanguard\UnityStub-Vanguard.sln'
-
-    # Build UnityStub
-    - name: Build UnityStub-Vanguard
-      run: msbuild '.\UnityStub-Vanguard\UnityStub-Vanguard.sln'
-
   ProcessStub:
     runs-on: windows-2019
     steps:

--- a/Development/Projects.json
+++ b/Development/Projects.json
@@ -20,11 +20,6 @@
         "exe": "FileStub-Vanguard/FileStub/bin/x64/Debug/FileStub.exe"
     },
     {
-        "name": "UnityStub",
-        "solutionPath": "UnityStub-Vanguard/UnityStub-Vanguard.sln",
-        "exe": "UnityStub-Vanguard/UnityStub/bin/x64/Debug/UnityStub.exe"
-    },
-    {
         "name": "ProcessStub",
         "solutionPath": "ProcessStub-Vanguard/ProcessStub-Vanguard.sln",
         "exe": "ProcessStub-Vanguard/ProcessStub/bin/x64/Debug/ProcessStub.exe"

--- a/Development/Run.ps1
+++ b/Development/Run.ps1
@@ -3,7 +3,7 @@ using module ".\Modules\Project.psm1"
 
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("RTCV","Bizhawk","CemuStub","FileStub","CemuStub","UnityStub","ProcessStub","melonDS","dolphin","pcsx2","citra","Dosbox")]
+    [ValidateSet("RTCV","Bizhawk","CemuStub","FileStub","CemuStub","ProcessStub","melonDS","dolphin","pcsx2","citra","Dosbox")]
     [String[]]$ProjectsToRun,
 
     [switch]$Release = $false # Run with the Release build configurations

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Icon graciously provided by [ShyGuyXXL](https://twitter.com/shyguyxxl)
 ## Features
 - Corrupts in real-time
 - Supports various emulators via a generic API. Currently comes with Bizhawk, Dolphin, PCSX2, melonDS, and Windows real-time implementations.
-- Supports corrupting files on-disk via the FileStub implementation, as well as including specialized support for certain kinds of files (WiiU games via CemuStub & Unity games via UnityStub).
+- Supports corrupting files on-disk via the FileStub implementation, as well as including specialized support for certain kinds of files.
 - Many corruption engines with customizable algorithms
 - Easy start option for autocorrupt
 - Glitch Harvester (Corruption Savestate Manager)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Icon graciously provided by [ShyGuyXXL](https://twitter.com/shyguyxxl)
 ## Features
 - Corrupts in real-time
 - Supports various emulators via a generic API. Currently comes with Bizhawk, Dolphin, PCSX2, melonDS, and Windows real-time implementations.
-- Supports corrupting files on-disk via the FileStub implementation, as well as including specialized support for certain kinds of files.
+- Supports corrupting files on-disk via the FileStub implementation, as well as including specialized support for certain kinds of files (WiiU games via CemuStub).
 - Many corruption engines with customizable algorithms
 - Easy start option for autocorrupt
 - Glitch Harvester (Corruption Savestate Manager)


### PR DESCRIPTION
Per discord discussions, UnityStub is deprecated. This PR removes UnityStub from the build scripts and CI to avoid build error noise.