### PR TITLE
Fix 'Index Out Of Range' in SavestateList

### DIFF
--- a/Source/Frontend/UI/Components/Controls/SavestateList.cs
+++ b/Source/Frontend/UI/Components/Controls/SavestateList.cs
@@ -178,7 +178,7 @@ namespace RTCV.UI.Components.Controls
                     if (holderIndex != -1)
                     {
                         var indexToRemove = holderIndex + _dataSource.Position;
-                        if (indexToRemove <= _dataSource.Count)
+                        if (indexToRemove >= 0 && indexToRemove <= _dataSource.Count)
                         {
                             _dataSource.RemoveAt(indexToRemove);
                         }

--- a/Source/Frontend/UI/Components/Engine Config/MemoryDomainsForm.cs
+++ b/Source/Frontend/UI/Components/Engine Config/MemoryDomainsForm.cs
@@ -191,7 +191,7 @@ namespace RTCV.UI
             if (e.Button == MouseButtons.Right)
             {
                 string vectorLimiter = S.GET<CorruptionEngineForm>().CurrentVectorLimiterListName;
-                var AutoLimitedDomains = MemoryDomains.AllMemoryInterfaces.Where(it => it.Value is VirtualMemoryDomain vmd && vmd.Name.Contains("->")).ToList();
+                var AutoLimitedDomains = MemoryDomains.AllMemoryInterfaces.Where(it => it.Value is VirtualMemoryDomain && it.Key.Contains("--")).ToList();
 
                 if (vectorLimiter != null)
                 {
@@ -236,7 +236,7 @@ namespace RTCV.UI
 
                             if (domain != null)
                             {
-                                string limiter = vmd.Name.Substring(vmd.Name.LastIndexOf('>') + 2);
+                                string limiter = vmd.Name.Substring(vmd.Name.LastIndexOf('-') + 2);
                                 S.GET<VmdLimiterProfilerForm>().AutoProfile(MemoryDomains.AllMemoryInterfaces[domain], limiter);
                             }
                         }


### PR DESCRIPTION
Fix 'index out of range' when attempting to delete a state when the statelist is already empty.