### PR TITLE
Fix 'Bake All Blastunits to VALUE'

### DIFF
--- a/Source/Frontend/UI/Forms/BlastEditorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastEditorForm.cs
@@ -1894,7 +1894,9 @@ namespace RTCV.UI
                     dgvBlastEditor.SelectedRows.Cast<DataGridViewRow>() :
                     dgvBlastEditor.Rows.Cast<DataGridViewRow>();
 
-                foreach (DataGridViewRow selected in targetRows
+                batchOperation = true;
+
+                foreach (var selected in targetRows
                     .Where((item => ((BlastUnit)item.DataBoundItem).IsLocked == false)))
                 {
                     var bu = (BlastUnit)selected.DataBoundItem;
@@ -1909,13 +1911,15 @@ namespace RTCV.UI
 
                 var i = 0;
                 //Insert the new one where the old row was, then remove the old row.
-                foreach (DataGridViewRow selected in dgvBlastEditor.SelectedRows.Cast<DataGridViewRow>()
+                foreach (var selected in targetRows
                     .Where((item => ((BlastUnit)item.DataBoundItem).IsLocked == false)))
                 {
                     bs.Insert(selected.Index, newBlastLayer.Layer[i]);
                     i++;
                     bs.Remove((BlastUnit)selected.DataBoundItem);
                 }
+
+                batchOperation = false;
             }
             catch (Exception ex)
             {

--- a/Source/Libraries/CorruptCore/BlastUnit.cs
+++ b/Source/Libraries/CorruptCore/BlastUnit.cs
@@ -933,8 +933,7 @@ namespace RTCV.CorruptCore
 
                         byte[] temp = new byte[Precision];
                         //We use this as it properly handles the length for us
-                        temp.AddValueToByteArrayUnchecked(randomValue, false);
-                        Value = temp;
+                        Value = temp.AddValueToByteArrayUnchecked(randomValue, false);
                     }
                 }
             }

--- a/Source/Libraries/CorruptCore/BlastUnit.cs
+++ b/Source/Libraries/CorruptCore/BlastUnit.cs
@@ -933,7 +933,8 @@ namespace RTCV.CorruptCore
 
                         byte[] temp = new byte[Precision];
                         //We use this as it properly handles the length for us
-                        Value = temp.AddValueToByteArrayUnchecked(randomValue, false);
+                        temp.AddValueToByteArrayUnchecked(randomValue, false);
+                        Value = temp;
                     }
                 }
             }


### PR DESCRIPTION
Blast Editor 'Bake All Blastunits to VALUE' now processes entire blastlayer instead of just the first unit. Individual selections still work as expected.