### PR TITLE
Fix Reroll for Units Above 8bit Precision

### DIFF
--- a/Source/Libraries/CorruptCore/BlastUnit.cs
+++ b/Source/Libraries/CorruptCore/BlastUnit.cs
@@ -933,8 +933,7 @@ namespace RTCV.CorruptCore
 
                         byte[] temp = new byte[Precision];
                         //We use this as it properly handles the length for us
-                        temp.AddValueToByteArrayUnchecked(randomValue, false);
-                        Value = temp;
+                        Value = temp.AddValueToByteArrayUnchecked(randomValue, false);
                     }
                 }
             }


### PR DESCRIPTION
Units of 16bits+ receive randomized values instead of all 00s (depending on settings; origin mode/lists are respected, except for unsupported bitlogiclists)