### PR TITLE
Fixed ListFilter Plugin Crash Loop

### DIFF
--- a/Source/Libraries/PluginHost/Host.cs
+++ b/Source/Libraries/PluginHost/Host.cs
@@ -28,6 +28,11 @@ namespace RTCV.PluginHost
             AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
         }
 
+        public void LoadPluginAssemblies(params string[] pluginDirs)
+        {
+            initialize(pluginDirs);
+        }
+
         private void initialize(string[] pluginDirs)
         {
             var catalog = new AggregateCatalog();

--- a/Source/Libraries/Vanguard/VanguardConnector.cs
+++ b/Source/Libraries/Vanguard/VanguardConnector.cs
@@ -17,6 +17,8 @@ namespace RTCV.Vanguard
 
         public VanguardConnector(NetCoreReceiver receiver)
         {
+            RtcCore.PluginHost.LoadPluginAssemblies("../RTCV/RTC/PLUGINS", "./PLUGINS");
+
             _receiver = receiver;
 
             LocalNetCoreRouter.registerEndpoint(this, NetCore.Endpoints.Vanguard);


### PR DESCRIPTION
Fixed a crash loop that occurred when a plugin implementing a new ListFilter class was unable to be deserialized on the emulator side after reconnecting to NetCore